### PR TITLE
updated description in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,9 +2,8 @@
 title: Fedora Developer Portal
 email: your-email@domain.com
 description: > # this means to ignore newlines until "baseurl:"
-  Write an awesome description for your new site here. You can edit this
-  line in _config.yml. It will appear in your document head meta (for
-  Google search results) and in your feed.xml site description.
+  Fedora Developer Portal provides information for developers running 
+  Fedora on their workstation or virtual machines.
 baseurl: "" # the subpath of your site, e.g. /blog/
 url: "http://developer.fedoraproject.org" # the base hostname & protocol for your site
 twitter_username: jekyllrb


### PR DESCRIPTION
The old description was the jekyll stock message,
so all google searches for Fedora Developer Portal
used this (it was in the meta tag)

This commit changes it to a sentence about Fedora
Developer Portal