### PR TITLE
Don't use @import to load css font

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,6 +12,7 @@
   <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
 
   <link href="/css/main.css" rel="stylesheet" media="screen, print">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,300">
   <link rel="stylesheet" href="/static/css/bootstrap.min.css">
 
   <!-- Site search -->

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -2,8 +2,6 @@
  * Site header
  */
 
-@import url(https://fonts.googleapis.com/css?family=Open+Sans:400,600,300);
-
 #logo-col img {
   margin-bottom: 15px;
 }


### PR DESCRIPTION
Using link rel='stylesheet' href='' instead of import allows to load the font file in parallel. 