### PR TITLE
*sass: Added basic table style.

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -215,7 +215,12 @@ table, th, td {
 
 table {
     display: table;
-    tbody {
+    margin-bottom: 25px;
+    &.bordered > thead > tr,
+    &.bordered > tbody > tr {
+        border-bottom: 1px solid $brand-color;
+    }
+    &.striped > tbody {
         > tr:nth-child(odd) {
             background-color: $background-color;
         }
@@ -226,10 +231,18 @@ table {
             border-radius: 0;
         }
     }
-    thead tr th,
-    tbody tr td,
-    tfoot tr td {
-        text-align: center;
+    &.highlight > tbody > tr {
+        @include transition(background-color .25s ease);
+        &:hover {
+            background-color: lighten($brand-color, 30%);
+        }
+    }
+    &.centered {
+        thead tr th,
+        tbody tr td,
+        tfoot tr td {
+            text-align: center;
+        }
     }
 }
 
@@ -243,7 +256,9 @@ tfoot {
 
 td,
 th {
-  padding: 5px 10px;
-  display: table-cell;
-  vertical-align: middle;
+    padding: 5px 10px;
+    display: table-cell;
+    text-align: left;
+    vertical-align: middle;
+    border-radius: 2px;
 }

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -203,3 +203,47 @@ pre {
         }
     }
 }
+
+
+
+/**
+ * Tables
+ */
+table, th, td {
+    border: none;
+}
+
+table {
+    display: table;
+    tbody {
+        > tr:nth-child(odd) {
+            background-color: $background-color;
+        }
+        > tr:nth-child(even) {
+            background-color: darken($background-color, 10%);
+        }
+        > tr > td {
+            border-radius: 0;
+        }
+    }
+    thead tr th,
+    tbody tr td,
+    tfoot tr td {
+        text-align: center;
+    }
+}
+
+thead {
+    border-bottom: 1px solid $brand-color;
+}
+
+tfoot {
+    border-top: 1px solid $brand-color;
+}
+
+td,
+th {
+  padding: 5px 10px;
+  display: table-cell;
+  vertical-align: middle;
+}


### PR DESCRIPTION
I would add **this** (slightly modified Q&D copypasta) as basic style to hopefully make the tables look a bit more reasonable in short term, with later discussion about adding some `.properties` to easily differentiate between different styles, with a note in the contributing docs.

Example styles:
https://github.com/RheaAyase/jekyll-rhea/blob/master/_sass/components/_global.scss#L40

Can be seen used [in my blog](http://rhea-ayase.eu/articles/2017-08/MTB-Dilemma) as centered and striped with this .md source:
```
{: .centered .striped}
| Camber | Ratio | Effective top speed |
|---|---|---|
| 28 | 2.80 | 33.6 km/h |
| 30 | 3.00 | 36.0 km/h |
```