### PR TITLE
Upgrade Vagrantfile to point to fedora-31

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,14 +6,14 @@
 #   jekyll serve --force_polling -H 0.0.0.0
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "fedora-28-cloud"
+  config.vm.box = "fedora-31-cloud"
 
   config.vm.provider :virtualbox do |virtualbox|
-    config.vm.box_url = "https://fedora.mirror.constant.com/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-28-1.1.x86_64.vagrant-libvirt.box"
+    config.vm.box_url = "https://fedora.mirror.constant.com/fedora/linux/releases/31/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-31-1.9.x86_64.vagrant-virtualbox.box"
   end
 
   config.vm.provider :libvirt do |libvirt|
-    config.vm.box_url = "https://fedora.mirror.constant.com/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-28-1.1.x86_64.vagrant-libvirt.box"
+    config.vm.box_url = "https://fedora.mirror.constant.com/fedora/linux/releases/31/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-31-1.9.x86_64.vagrant-libvirt.box"
   end if Vagrant.has_plugin?('vagrant-libvirt')
 
   config.vm.network "forwarded_port", guest: 4000, host: 4000


### PR DESCRIPTION
Received the following error when trying to run with previous `Vagrantfile` Upgrade to Fedora 31 fixed the error and allowed me to build a local docker image.

```console
Configuration file: /opt/developerportal/website/_config.yml
  Dependency Error: Yikes! It looks like you don't have jekyll-email-protect or one of its dependencies installed. In order to use Jekyll as currently configured, you'll need to install this gem. The full error message from Ruby is: 'cannot load such file -- jekyll-email-protect' If you run into trouble, you can find helpful resources at https://jekyllrb.com/help/! 
jekyll 3.8.3 | Error:  jekyll-email-protect
```