### PR TITLE
Add "Report an issue" button to content pages.

### DIFF
--- a/_layouts/content.html
+++ b/_layouts/content.html
@@ -37,6 +37,7 @@ layout: default
           </div>
 
           <a href="https://github.com/developer-portal/content/edit/master{{page.dir}}{{page.name}}" class="btn btn-default">Edit this page</a>
+          <a href="https://github.com/developer-portal/content/issues/new?title={{page.section}}:+{{page.subsection}}+{{page.name}}&body=Describe+the+problem" class="btn btn-default">Report an issue</a>
         </div>
         <div class="col-sm-9">
           <div class="panel panel-default content-content">


### PR DESCRIPTION
The button redirects from content pages to new issue creation for GitHub with
predefined title and body of the issue to help point maintainers toward the issue.

It grabs the section and page subtitle and subsection from markdown headers of the pages.

The format for title is as follows: `<section>: <subsection> <page name>`

An example issue created by the link looks like this:
```
tech-languages: dotnet about.md

Describe the problem
```

Fixes https://github.com/developer-portal/content/issues/103