### PR TITLE
Scale content images to fit device size.

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -242,6 +242,11 @@ div.content-content {
     margin-left: 0px;
     color: #111;
   }
+
+  img {
+    object-fit: scale-down;
+    width: 100%;
+  }
 }
 
 


### PR DESCRIPTION
Tested locally, looks like it works correctly and the images outside the content are being left out of this scaling. 

Fixes: developer-portal/content#383 and developer-portal/content#213