### PR TITLE
Add content-deprecation.html to include in out-of-date content.

### DIFF
--- a/_includes/content-deprecation.html
+++ b/_includes/content-deprecation.html
@@ -1,0 +1,5 @@
+<div class="alert alert-warning" role="alert">
+  <strong>This page is deprecated!</strong>
+  The following information is outdated
+  and will be removed in 6 months.
+</div>


### PR DESCRIPTION
Some content is too old to work on current set of Fedoras. This notice gives a way to let the community know that those pages do not contain reliable and current information.
Pages that include the deprecation notice will be removed in 6 months from adding the notice.

If page will include the notice, a notification email asking for community action to update the pages.

===

This can be embedded into the content page with `{% include content-deprecation.html %}`

The included section looks like this.

![2022-10-03T13:49:34,219885570+02:00](https://user-images.githubusercontent.com/33065078/193570075-0dd273f8-c6e0-4228-9b79-2f098a98c00f.png)
