### PR TITLE
layout/content: issue / edit buttons open new tab

### DIFF
--- a/_layouts/content.html
+++ b/_layouts/content.html
@@ -36,8 +36,8 @@ layout: default
             </div>
           </div>
 
-          <a href="https://github.com/developer-portal/content/edit/master{{page.dir}}{{page.name}}" class="btn btn-default">Edit this page</a>
-          <a href="https://github.com/developer-portal/content/issues/new?title={{page.section}}:+{{page.subsection}}+{{page.name}}&body=Describe+the+problem" class="btn btn-default">Report an issue</a>
+          <a target="_blank" href="https://github.com/developer-portal/content/edit/master{{page.dir}}{{page.name}}" class="btn btn-default">Edit this page</a>
+          <a target="_blank" href="https://github.com/developer-portal/content/issues/new?title={{page.section}}:+{{page.subsection}}+{{page.name}}&body=Describe+the+problem" class="btn btn-default">Report an issue</a>
         </div>
         <div class="col-sm-9">
           <div class="panel panel-default content-content">


### PR DESCRIPTION
I don't see why we would redirect a person from viewing the page they're very likely to look at to find the line to edit in the source (need to have both open at that time).