### PR TITLE
Fix "Report an issue" button not filling section

### DIFF
--- a/_includes/jumbo-content.html
+++ b/_includes/jumbo-content.html
@@ -1,28 +1,8 @@
 <div class="row" id="headlines">
   <div class="col-sm-12">
-    {% for p in site.pages %}
-      {% if p.subsection == page.subsection %}
-        {% if p.section %}
-          <img class="img-rounded" src="{{ p.subsection | subsection_logo }}">
-        {% endif %}
-      {% endif %}
-    {% endfor %}
-
-    {% for p in site.pages %}
-      {% if p.subsection == page.subsection %}
-        {% if p.section %}
-          <h2>{{ p.title }}</h2>
-        {% endif %}
-      {% endif %}
-    {% endfor %}
-
-    {% for p in site.pages %}
-      {% if p.subsection == page.subsection %}
-        {% if p.section %}
-          <p>{{ p.description }}</p>
-        {% endif %}
-      {% endif %}
-    {% endfor %}
+    <img class="img-rounded" src="{{ page.subsection | subsection_logo }}">
+    <h2>{{ page.title }}</h2>
+    <p>{{ page.description }}</p>
   </div>
 </div>
 <div class="row" id="attribution">

--- a/_layouts/content.html
+++ b/_layouts/content.html
@@ -17,16 +17,7 @@ layout: default
             {% assign sorted_pages = site.pages | sort: "order" %}
             {% for p in sorted_pages %}
               {% if p.subsection == page.subsection %}
-                {% if p.section %}
                 <a href="{{p.url}}" class="list-group-item {% if p.url == page.url %} active {% endif %}">{{ p.title }}</a>
-                {% endif %}
-              {% endif %}
-            {% endfor %}
-            {% for p in sorted_pages %}
-              {% if p.subsection == page.subsection %}
-                {% if p.section %}{% else %}
-                <a href="{{p.url}}" class="list-group-item {% if p.url == page.url %} active {% endif %}">{{ p.title }}</a>
-                {% endif %}
               {% endif %}
             {% endfor %}
           </div>
@@ -35,7 +26,6 @@ layout: default
               {% include ask_fedora.html %}
             </div>
           </div>
-
           <a target="_blank" href="https://github.com/developer-portal/content/edit/master{{page.dir}}{{page.name}}" class="btn btn-default">Edit this page</a>
           <a target="_blank" href="https://github.com/developer-portal/content/issues/new?title={{page.section}}:+{{page.subsection}}+{{page.name}}&body=Describe+the+problem" class="btn btn-default">Report an issue</a>
         </div>


### PR DESCRIPTION
The idea here is to add subsections to every page, rather than just the "parent" page. Depends on developer-portal/content#532

This seems like a rather drastic change from current functionality, but I couldn't really see a reason for it to be so complex so I made a leap of faith and cut down on the complexity in the hopes it really wasn't needed. The specs seem to not be very reliable, but I didn't notice any _more_ fails with this change, so I'm hopeful.