### PR TITLE
Use page's category name instead of section for reporting issues.

### DIFF
--- a/_layouts/content.html
+++ b/_layouts/content.html
@@ -37,7 +37,7 @@ layout: default
           </div>
 
           <a target="_blank" href="https://github.com/developer-portal/content/edit/master{{page.dir}}{{page.name}}" class="btn btn-default">Edit this page</a>
-          <a target="_blank" href="https://github.com/developer-portal/content/issues/new?title={{page.section}}:+{{page.subsection}}+{{page.name}}&body=Describe+the+problem" class="btn btn-default">Report an issue</a>
+          <a target="_blank" href="https://github.com/developer-portal/content/issues/new?title={{page.category-name}}:+{{page.subsection}}+{{page.name}}&body=Describe+the+problem" class="btn btn-default">Report an issue</a>
         </div>
         <div class="col-sm-9">
           <div class="panel panel-default content-content">


### PR DESCRIPTION
Instead of trying to add sections, the `_config.yml` file already has needed category-name that seem to get mapped correctly onto individual sections, which means we don't have to keep the record of pages on each of content's .md file.

If we would want to be more fine-grained, we should be able to do that also via `_config.yml` by just appending the values for the specific subdirectory.