### PR TITLE
Simplify html templates

### DIFF
--- a/_includes/jumbo-content.html
+++ b/_includes/jumbo-content.html
@@ -4,21 +4,7 @@
       {% if p.subsection == page.subsection %}
         {% if p.section %}
           <img class="img-rounded" src="{{ p.subsection | subsection_logo }}">
-        {% endif %}
-      {% endif %}
-    {% endfor %}
-
-    {% for p in site.pages %}
-      {% if p.subsection == page.subsection %}
-        {% if p.section %}
           <h2>{{ p.title }}</h2>
-        {% endif %}
-      {% endif %}
-    {% endfor %}
-
-    {% for p in site.pages %}
-      {% if p.subsection == page.subsection %}
-        {% if p.section %}
           <p>{{ p.description }}</p>
         {% endif %}
       {% endif %}

--- a/_layouts/content.html
+++ b/_layouts/content.html
@@ -17,16 +17,7 @@ layout: default
             {% assign sorted_pages = site.pages | sort: "order" %}
             {% for p in sorted_pages %}
               {% if p.subsection == page.subsection %}
-                {% if p.section %}
-                <a href="{{p.url}}" class="list-group-item {% if p.url == page.url %} active {% endif %}">{{ p.title }}</a>
-                {% endif %}
-              {% endif %}
-            {% endfor %}
-            {% for p in sorted_pages %}
-              {% if p.subsection == page.subsection %}
-                {% if p.section %}{% else %}
-                <a href="{{p.url}}" class="list-group-item {% if p.url == page.url %} active {% endif %}">{{ p.title }}</a>
-                {% endif %}
+              <a href="{{p.url}}" class="list-group-item {% if p.url == page.url %} active {% endif %}">{{ p.title }}</a>
               {% endif %}
             {% endfor %}
           </div>


### PR DESCRIPTION
The template code seems to contain unneeded repetition. This PR cuts down on the repetition in HTML templates, while keeping the rendered content the same (same output AFAICT, smaller code). 