### PR TITLE
Correct FAS link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -58,7 +58,7 @@
               <dd><a href="https://fedoraproject.org/wiki/Join">Join Fedora</a></dd>
               <dd><a href="http://fedoraplanet.org">Planet Fedora</a></dd>
               <dd><a href="https://fedoraproject.org/wiki/SIGs">Fedora SIGs</a></dd>
-              <dd><a href="https://admin.fedoraproject.org/accounts/">Fedora Account System</a></dd>
+              <dd><a href="https://accounts.fedoraproject.org/">Fedora Account System</a></dd>
               <dd><a href="https://fedoracommunity.org/">Fedora Community</a></dd>
             </dl>
           </div>


### PR DESCRIPTION
The Fedora Account System link is broken, correct the link.